### PR TITLE
fix: Added async to xcode download

### DIFF
--- a/tasks/install-Xcode.yml
+++ b/tasks/install-Xcode.yml
@@ -11,6 +11,8 @@
   get_url:
     url: https://s3.amazonaws.com/boxes.10gen.com/build/xcode/Xcode_{{ item.major }}.{{ item.minor }}.xip
     dest: "/Applications/Xcode_{{ item.major }}.{{ item.minor }}.xip"
+  async: 600
+  poll: 60
   when: not xcode_xip.stat.exists
 
 # This takes up to 6 minutes


### PR DESCRIPTION
### Description

This is so that the download doesn't time out the ssh connection

### Testing

```
make test
```
