### PR TITLE
fix: Removed checksum check to speed up stat

### DIFF
--- a/tasks/install-Xcode.yml
+++ b/tasks/install-Xcode.yml
@@ -4,6 +4,7 @@
   become: true
   stat:
     path: "/Applications/Xcode_{{ item.major }}.{{ item.minor }}.xip"
+    get_checksum: false
   register: xcode_xip
 
 - name: Download Xcode


### PR DESCRIPTION
### Description

Removing get_checksum speeds up stat for larger files.

### Testing

```
make test
```
