### PR TITLE
fix: Skip unxip step to speed up role

### DIFF
--- a/tasks/install-Xcode.yml
+++ b/tasks/install-Xcode.yml
@@ -24,6 +24,7 @@
   args:
     creates: /Applications/Xcode{{ item.major }}.app
     chdir: /Applications/
+  when: not xcode_xip.stat.exists
 
 - name: Move xcode to correct directory
   become: true


### PR DESCRIPTION
### Description

Using the when parameter to skip the unxip step speeds up the role without any downside

### Testing

```
make test
```
