### PR TITLE
fix: Use command to check if Xcode is installed

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -1,0 +1,26 @@
+---
+jobs:
+  test:
+    name: molecule test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up private key
+        env:
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        run: |
+          mkdir ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${{ secrets.PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install required dependencies
+        run: pip install -r requirements.txt
+      - run: molecule test --all
+name: Molecule Test
+"on":
+  - push
+  - pull_request

--- a/tasks/install-Xcode.yml
+++ b/tasks/install-Xcode.yml
@@ -2,10 +2,10 @@
 # Item refers to xcode_versions passed in from main.yml
 - name: Check if Xcode {{ item.major }} is already downloaded
   become: true
-  stat:
-    path: "/Applications/Xcode_{{ item.major }}.{{ item.minor }}.xip"
-    get_checksum: false
-  register: xcode_xip
+  command: /Applications/Xcode{{ item.major }}.{{ item.minor }}.app/Contents/Developer/usr/bin/xcodebuild -version
+  register: xcode_installed
+  changed_when: false
+  ignore_errors: true
 
 - name: Download Xcode
   become: true
@@ -14,7 +14,7 @@
     dest: "/Applications/Xcode_{{ item.major }}.{{ item.minor }}.xip"
   async: 600
   poll: 60
-  when: not xcode_xip.stat.exists
+  when: xcode_installed.rc != 0
 
 - name: Unxip xcode {{ item.major }}
   become: true
@@ -24,7 +24,7 @@
   args:
     creates: /Applications/Xcode{{ item.major }}.app
     chdir: /Applications/
-  when: not xcode_xip.stat.exists
+  when: xcode_installed.rc != 0
 
 - name: Move xcode to correct directory
   become: true


### PR DESCRIPTION
This change will not require the Xcode xip to be present in order to
check if Xcode is installed. This will save some precious space on our
Macs.