### PR TITLE
fix: Check for the final install folder

### DIFF
--- a/tasks/install-Xcode.yml
+++ b/tasks/install-Xcode.yml
@@ -3,7 +3,7 @@
 - name: Check if Xcode {{ item.major }} is already downloaded
   become: true
   stat:
-    path: "/Applications/Xcode_{{ item.major }}.{{ item.minor }}.xip"
+    path: "/Applications/Xcode{{ item.major }}.{{ item.minor }}.app"
     get_checksum: false
   register: xcode_xip
 


### PR DESCRIPTION
This will allow the xip directory to be deleted after installing Xcode